### PR TITLE
Do not crash if store definitions use windows & document browser globals

### DIFF
--- a/fixtures/store-test-with-globals.js
+++ b/fixtures/store-test-with-globals.js
@@ -1,0 +1,63 @@
+
+export default function () {
+  const ls = window.localStorage.getItem('test')
+  const el = document.querySelector('.test')
+
+  return {
+    state: {},
+    getters: {
+      companyName () { return ls } // --> getters['companyName']
+    },
+    mutations: {
+      incrementTimer () { } // --> commit['incrementTimer']
+    },
+    actions: {
+      reportSome () { } // --> dispatch['reportSome']
+    },
+    modules: {
+      account: {
+        namespaced: true,
+
+        // module assets
+        state: { },
+        getters: {
+          isAdmin () { return el } // -> getters['account/isAdmin']
+        },
+        actions: {
+          login () { } // -> dispatch('account/login')
+        },
+        mutations: {
+          login () { } // -> commit('account/login')
+        },
+
+        // nested modules
+        modules: {
+          // inherits the namespace from parent module
+          myPage: {
+            state: { },
+            getters: {
+              profile () { } // -> getters['account/profile']
+            }
+          },
+
+          // further nest the namespace
+          posts: {
+            namespaced: true,
+
+            state: { },
+            getters: {
+              popular () { } // -> getters['account/posts/popular']
+            },
+            modules: {
+              comments: {
+                actions: {
+                  comment (text) { } // -> actions['account/posts/comment']
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint": "standard main.js **/*.js",
     "test-exported-obj": "node main.js ./fixtures/store-test-obj.js | diff fixtures/store-test-output.js -",
     "test-exported-func": "node main.js ./fixtures/store-test-func.js | diff fixtures/store-test-output.js -",
-    "test": "npm run -s test-exported-obj && npm run -s test-exported-func"
+    "test-exported-with-globals": "node main.js ./fixtures/store-test-with-globals.js | diff fixtures/store-test-output.js -",
+    "test": "npm run -s test-exported-obj && npm run -s test-exported-func && npm run -s test-exported-with-globals"
   },
   "dependencies": {
     "babel-plugin-transform-runtime": "^6.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuex-type-const-generator",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Generate a file with constants for getters, actions and mutations from a Vuex store definition",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Because this tool import the store definition modules in Node, if the store definitions use `window` or `document` globals at initialization time then the tool crahsed.

This PR added a fake object for both of them and injected in `global` NodeJS object, for making them available to the imported store definitions, which allows to call any property and call each property as function, moreover of being able to be stringified because they implement `toString` and `toJSON`.

Once this PR be merged, the new version would be published in NPM